### PR TITLE
allow for arbitrary chromosome identifiers

### DIFF
--- a/bin/make_plot.R
+++ b/bin/make_plot.R
@@ -76,7 +76,8 @@ geneTrack <- GeneRegionTrack(
   chromosome=chr,
   start=window_start,
   end=window_end,
-  fontsize=8,panel.only=TRUE
+  fontsize=8,panel.only=TRUE,
+  options(ucscChromosomeNames=FALSE)
 )
 ranges(geneTrack)$feature <- as.character(ranges(geneTrack)$feature)
 ranges(geneTrack) <- ranges(geneTrack)[ranges(geneTrack)$feature!="transcript"]


### PR DESCRIPTION
Made only one change: added "options(ucscChromosomeNames=FALSE)" to the "GeneRegionTrack" function call in make_plot.R. This allows the use of a GFF3 file with "non-standard" chromosome names, e.g. chromosome "Mt" in Arabidopsis TAIR 10 genome. 